### PR TITLE
Update the schedule for the next few weeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ Some weeks have a special theme!
 
 | Date* | Topic |
 | ---- | ----- |
-| 2022-12-19 | ["Unix, Plan 9, and the Lurking Smalltalk"], by Stephen Kell |
+| 2022-12-20 | ["Unix, Plan 9, and the Lurking Smalltalk"], by Stephen Kell |
+| 2022-12-27 | Holiday break, no office hours |
+| 2023-01-03 | Holiday break, no office hours |
+| 2023-01-10 | ["Deconstruct Files"], by Dan Luu |
 
-* In some time zones, the second meeting time is on the following day.
+* In some time zones, including American time zones, the first meeting time is on the previous day.
 
 ["Unix, Plan 9, and the Lurking Smalltalk"]: https://www.humprog.org/~stephen/research/papers/kell19unix-personal.pdf
+["Deconstruct Files"]: https://danluu.com/deconstruct-files/


### PR DESCRIPTION
 - No office hours over holiday break on 12-26 or 01-03.
 - Add a special theme for 01-10: Deconstruct Files
 - Use the UTC time in the special-themes dates.